### PR TITLE
Make sure new selection is visible when swiping text view

### DIFF
--- a/UUTextField.m
+++ b/UUTextField.m
@@ -248,26 +248,31 @@
 - (void) uuBackOneLetter
 {
 	[UIView uuTextInputBackOneLetter:self];
+	[self scrollRangeToVisible:self.selectedRange];
 }
 
 - (void) uuAdvanceOneLetter
 {
 	[UIView uuTextInputAdvanceOneLetter:self];
+	[self scrollRangeToVisible:self.selectedRange];
 }
 
 - (void) uuBackOneWord
 {
 	[UIView uuTextInputBackOneWord:self];
+	[self scrollRangeToVisible:self.selectedRange];
 }
 
 - (void) uuAdvanceOneWord
 {
 	[UIView uuTextInputAdvanceOneWord:self];
+	[self scrollRangeToVisible:self.selectedRange];
 }
 
 - (void) uuAddGestureNavigation
 {
 	[UIView uuAddGestureNavigationToTextInput:self];
+	[self scrollRangeToVisible:self.selectedRange];
 }
 
 @end


### PR DESCRIPTION
Loving the work you've done with swipe/gesture navigation stuff on UITextField/UITextView. 

Possibly made a change that could be useful. When swiping a UITextView it'll scroll to make sure the selection is visible.

It's done by returning the selection range from the advance/back methods and using `-[UITextView scrollRangeToVisible:]`. Writing this just now, I did realise that UITextView has its own `selectedRange` which could have been used instead of what I've done, don't think I'm knowledgable enough to know whether there are any downsides to either though.
