### PR TITLE
Add default time zone hook and usage examples

### DIFF
--- a/UUDate.h
+++ b/UUDate.h
@@ -61,8 +61,26 @@
 // Date Parsing
 @interface NSDate (UUDateParsing)
 
+// Uses kUURFC3339DateTimeFormatter
+//
+// Example:
+//
+// NSDate* d = [NSDate uuDateFromRfc3339String:@"1776-07-04T12:30:00Z"];
+//
+// or
+//
+// NSDate* d = [NSDate uuDateFromRfc3339String:@"1776-07-04T12:30:00-700"];
+//
 + (NSDate*) uuDateFromRfc3339String:(NSString*)string;
+
+// Uses kUUISO8601DateTimeFormatter
+//
+// Example:
+//
+// NSDate* d = [NSDate uuDateFromIso8601String:@"1776-07-04 12:30:00"];
 + (NSDate*) uuDateFromIso8601String:(NSString*)string;
+
+
 + (NSDate*) uuDateFromString:(NSString*)string withFormat:(NSString*)format;
 
 @end
@@ -73,6 +91,7 @@
 @interface NSDateFormatter (UUDateFormatterCache)
 
 + (NSDateFormatter*) uuCachedDateFormatter:(NSString*)dateFormat;
++ (void) uuSetDefaultTimeZone:(NSTimeZone*)timeZone;
 
 @end
 

--- a/UUDate.m
+++ b/UUDate.m
@@ -140,7 +140,12 @@ NSString * const kUUDayOfWeekDateFormatter          = @"EEEE";
 - (NSString*) uuStringFromDate:(NSString*)formatter timeZone:(NSTimeZone*)timeZone
 {
     NSDateFormatter* df = [NSDateFormatter uuCachedDateFormatter:formatter];
-    df.timeZone = timeZone;
+    
+    if (timeZone)
+    {
+        df.timeZone = timeZone;
+    }
+    
     return [df stringFromDate:self];
 }
 
@@ -290,6 +295,7 @@ const double kUUSecondsPerDay = (60 * 60 * 24);
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Date Format Caching
 static NSMutableDictionary* theSharedDateFormatterCache = nil;
+static NSTimeZone* theDefaultTimeZone = nil;
 
 @implementation NSDateFormatter (UUDateFormatterCache)
 
@@ -314,8 +320,13 @@ static NSMutableDictionary* theSharedDateFormatterCache = nil;
         [cache setValue:df forKey:dateFormat];
     }
     
+    [df setTimeZone:theDefaultTimeZone];
     return df;
-    
+}
+
++ (void) uuSetDefaultTimeZone:(NSTimeZone*)timeZone
+{
+    theDefaultTimeZone = timeZone;
 }
 
 @end


### PR DESCRIPTION
- Added hook to specify default time zone to be used by cached NSDateFormatters
- Added usage examples of [NSDate uuDateFromXYZ] methods
